### PR TITLE
feat: Update to release version of decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-poetry = "^1.7.1"
-reqstool-python-decorators = "^0.0.1"
+poetry = "1.7.1"
+reqstool-python-decorators = "0.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = { version = "24.2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.10"
 poetry = "^1.7.1"
-reqstool-python-decorators = "^0.1.dev6" #Change later when proper release is made. 
+reqstool-python-decorators = "^0.0.1"
 
 [tool.poetry.group.dev.dependencies]
 black = { version = "24.2.0" }


### PR DESCRIPTION
This PR updates dependency to reqstool-python-decorators to an official version. A release of this repository will be done after merge. 