### PR TITLE
36 add reqstool configyml to sdist

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -10,12 +10,6 @@ The package name is `reqstool-python-poetry-plugin`.
 $poetry add reqstool-python-poetry-plugin 
 ```
 
-* pip install (unsure if working as intended):
-
-```
-$pip install reqstool-python-poetry-plugin
-```
-
 === Dependencies
 
 ==== reqstool-decorators

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -2,25 +2,29 @@
 
 === pyproject.toml
 
-==== Paths
+==== Configuration
 
-The plugin gets the paths where it will look for decorated code from ("." is filtered out):
+The plugin is configured in the `pyproject.toml` file.
 
-```
-[tool.pytest.ini_options]
-pythonpath = [".", "src", "tests"]
-```
+```toml
+[tool.reqstool]
+sources = ["src", "tests"]
+test_results = "build/**/junit.xml"
+dataset_directory = "docs/reqstool"
+output_directory = "build/reqstool"
 
-In this example all files in "src" and "tests", including subfolders, will be processed.
+This specifies where the plugin should be applied: `sources`, where test reports are located: `test_results`, where reqstool files are located: `dataset_directory` and output directory: `output_directory`.
 
 ==== Poetry
 
 This will be added when running `poetry add reqstool-python-poetry-plugin`
 
-```
+```toml
 [tool.poetry.dependencies]
 reqstool-python-poetry-plugin = "<version>"
 ```
+
+
 
 === Decorators
 
@@ -46,4 +50,6 @@ def test_somefunction():
 
 === Poetry build
 
-When running `$poetry build` or `$poetry install` the plugin will run the `activate` function located inside `DecoratorsPlugin` class, calling functions from the `reqstool-python-decorators` package and generate a annotations.yml file in the `build/reqstool/` folder containing formatted data on all decorated code found.
+When running `$poetry build` or `$poetry install` the plugin will run the `activate` function located inside `ReqstoolPlugin` class, calling functions from the `reqstool-python-decorators` package and generate a annotations.yml file in the `build/reqstool/` folder containing formatted data on all decorated code found.
+
+Additionaly it will generate a `reqstool_config.yml` in the root of the project.

--- a/docs/reqstool/reqstool_config.yml
+++ b/docs/reqstool/reqstool_config.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+
+language: python
+build: poetry
+resources:
+  requirements: requirements.yml
+  software_verification_cases: software_verification_cases.yml
+  manual_verification_results: manual_verification_results.yml
+  annotations: ../../build/reqstool/annotations.yml
+  test_results:
+    - ../../build/**/*.xml

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+
+metadata:
+  urn: reqstool-python-poetry-plugin
+  variant: microservice
+  title: Reqstool client
+  url: https://github.com/Luftfartsverket/reqstool-python-poetry-plugin
+
+requirements:
+  - id: REQ_001
+    title: First requirement
+    significance: shall
+    description: Some description of the requirement.
+    categories: [functional-suitability]
+    revision: 0.0.1
+  - id: REQ_002
+    title: Second requirement
+    significance: shall
+    description: Some description of the requirement.
+    categories: [functional-suitability]
+    revision: 0.0.1
+  - id: REQ_003
+    title: Third requirement
+    significance: shall
+    description: Some description of the requirement.
+    categories: [functional-suitability]
+    revision: 0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python = "^3.10"
 poetry = "1.8.4"
 reqstool-python-decorators = "0.0.5"
 poetry-dynamic-versioning = "^1.2.0"
+# ruamel.yaml = { version = "0.18.6" }
 
 [tool.poetry.group.dev.dependencies]
 black = { version = "24.10.0" }
@@ -35,14 +36,26 @@ flake8 = { version = "7.1.1" }
 flake8-pyproject = { version = "1.2.3" }
 pytest = { version = "8.3.3" }
 pytest-cov = { version = "5.0.0" }
+# ruamel.yaml = { version = "0.18.6" }
 
 [tool.poetry.plugins."poetry.plugin"]
-reqstool = "reqstool_python_poetry_plugin.plugin:DecoratorsPlugin"
+reqstool = "reqstool_python_poetry_plugin.plugin:ReqstoolPlugin"
 
 [tool.pytest.ini_options]
-addopts = ["-s", "--import-mode=importlib"]
+addopts = [
+    "-rsxX",
+    "-s",
+    "--import-mode=importlib",
+    "--log-cli-level=DEBUG",
+    '-m not slow or not integration',
+]
 pythonpath = [".", "src", "tests"]
-testpaths = ["tests/unit"]
+testpaths = ["tests"]
+markers = [
+    "flaky: tests that can randomly fail through no change to the code",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "integration: tests that require external resources",
+]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 build-backend = "poetry_dynamic_versioning.backend"
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 
-
 [tool.poetry]
 name = "reqstool-python-poetry-plugin"
 version = "0.0.0"
@@ -20,15 +19,11 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 
-[project.scripts]
-# section needed for poetry convertion
-
 [tool.poetry.dependencies]
 python = "^3.10"
 poetry = "1.8.4"
 reqstool-python-decorators = "0.0.5"
 poetry-dynamic-versioning = "^1.2.0"
-# ruamel.yaml = { version = "0.18.6" }
 
 [tool.poetry.group.dev.dependencies]
 black = { version = "24.10.0" }
@@ -36,7 +31,6 @@ flake8 = { version = "7.1.1" }
 flake8-pyproject = { version = "1.2.3" }
 pytest = { version = "8.3.3" }
 pytest-cov = { version = "5.0.0" }
-# ruamel.yaml = { version = "0.18.6" }
 
 [tool.poetry.plugins."poetry.plugin"]
 reqstool = "reqstool_python_poetry_plugin.plugin:ReqstoolPlugin"
@@ -65,7 +59,6 @@ target-version = ['py310']
 ignore = ["W503"]
 max-line-length = 120
 max-complexity = 10
-
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/src/reqstool_python_poetry_plugin/plugin.py
+++ b/src/reqstool_python_poetry_plugin/plugin.py
@@ -7,13 +7,10 @@ import tarfile
 import tempfile
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any
 
 from cleo.io.io import IO
 from poetry.plugins.plugin import Plugin
 from poetry.poetry import Poetry
-from poetry.core.masonry.builders.wheel import WheelBuilder
-from poetry.core.masonry.builders.sdist import SdistBuilder
 from reqstool_python_decorators.processors.decorator_processor import DecoratorProcessor
 from ruamel.yaml import YAML
 
@@ -51,17 +48,7 @@ class ReqstoolPlugin(Plugin):
         # filtered_pythonpaths: list[str] = [path for path in pythonpath_from_pyproject_toml if path != "."]
 
         self._create_annotations_file(poetry=poetry)
-        # self._append_to_sdist_tar_gz(cleo_io=self._cleo_io, poetry=self._poetry)
-
-    @property
-    def post_build_handlers(self):
-        return [self.handle_post_build]
-
-    def handle_post_build(self, builder: Any, **kwargs: dict[str, Any]) -> None:
-        if isinstance(builder, (WheelBuilder, SdistBuilder)):
-            self._cleo_io.write_line("APPENDING TO TAR.GZ")
-
-            self._append_to_sdist_tar_gz(cleo_io=self._cleo_io, poetry=self._poetry)
+        self._append_to_sdist_tar_gz(cleo_io=self._cleo_io, poetry=self._poetry)
 
     def _create_annotations_file(self, poetry: Poetry) -> None:
         """

--- a/src/reqstool_python_poetry_plugin/plugin.py
+++ b/src/reqstool_python_poetry_plugin/plugin.py
@@ -16,7 +16,7 @@ class ReqstoolPlugin(Plugin):
     CONFIG_SOURCES = "sources"
     CONFIG_DATASET_DIRECTORY = "dataset_directory"
     CONFIG_OUTPUT_DIRECTORY = "output_directory"
-    CONFIG_TEST_RESULTS: str = "test_results"
+    CONFIG_TEST_RESULTS = "test_results"
 
     INPUT_FILE_REQUIREMENTS_YML: str = "requirements.yml"
     INPUT_FILE_SOFTWARE_VERIFICATION_CASES_YML: str = "software_verification_cases.yml"
@@ -70,9 +70,19 @@ class ReqstoolPlugin(Plugin):
             .get("reqstool", {})
             .get(self.CONFIG_OUTPUT_DIRECTORY, self.OUTPUT_DIR_REQSTOOL)
         )
-        test_result_patterns: list[str] = (
+        # test_result_patterns: list[str] = (
+        #     poetry.pyproject.data.get("tool", {}).get("reqstool", {}).get(self.CONFIG_TEST_RESULTS, [])
+        # )
+
+        test_results_config = (
             poetry.pyproject.data.get("tool", {}).get("reqstool", {}).get(self.CONFIG_TEST_RESULTS, [])
         )
+
+        # Convert string to list if it's a string
+        test_result_patterns: list[str] = (
+            [test_results_config] if isinstance(test_results_config, str) else test_results_config
+        )
+
         requirements_file: Path = Path(dataset_directory, self.INPUT_FILE_REQUIREMENTS_YML)
         svcs_file: Path = Path(dataset_directory, self.INPUT_FILE_SOFTWARE_VERIFICATION_CASES_YML)
         mvrs_file: Path = Path(dataset_directory, self.INPUT_FILE_MANUAL_VERIFICATION_RESULTS_YML)
@@ -105,7 +115,7 @@ class ReqstoolPlugin(Plugin):
                 f"[reqstool] added test_results to {self.OUTPUT_SDIST_REQSTOOL_YML}: {test_result_patterns}"
             )
 
-        reqstool_yaml_data = {"language": "python", "build": "hatch", "resources": resources}
+        reqstool_yaml_data = {"language": "python", "build": "poetry", "resources": resources}
         yaml = YAML()
         yaml.default_flow_style = False
 

--- a/src/reqstool_python_poetry_plugin/plugin.py
+++ b/src/reqstool_python_poetry_plugin/plugin.py
@@ -1,25 +1,194 @@
 # Copyright © LFV
 
+import gzip
+import io
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
 
 from cleo.io.io import IO
 from poetry.plugins.plugin import Plugin
 from poetry.poetry import Poetry
+from poetry.core.masonry.builders.wheel import WheelBuilder
+from poetry.core.masonry.builders.sdist import SdistBuilder
 from reqstool_python_decorators.processors.decorator_processor import DecoratorProcessor
+from ruamel.yaml import YAML
 
 
-class DecoratorsPlugin(Plugin):
-    def activate(self, poetry: Poetry, io: IO):
-        io.write_line("INSIDE ACTIVATE IN DECORATORSPLUGIN")
+class ReqstoolPlugin(Plugin):
 
-        pythonpath_from_pyproject_toml = (
-            poetry.pyproject.data.get("tool").get("pytest").get("ini_options").get("pythonpath")
+    CONFIG_SOURCES = "sources"
+    CONFIG_DATASET_DIRECTORY = "dataset_directory"
+    CONFIG_OUTPUT_DIRECTORY = "output_directory"
+    CONFIG_TEST_RESULTS: str = "test_results"
+
+    INPUT_FILE_REQUIREMENTS_YML: str = "requirements.yml"
+    INPUT_FILE_SOFTWARE_VERIFICATION_CASES_YML: str = "software_verification_cases.yml"
+    INPUT_FILE_MANUAL_VERIFICATION_RESULTS_YML: str = "manual_verification_results.yml"
+    INPUT_FILE_JUNIT_XML: str = "build/junit.xml"
+    INPUT_FILE_ANNOTATIONS_YML: str = "annotations.yml"
+    INPUT_DIR_DATASET: str = "reqstool"
+
+    OUTPUT_DIR_REQSTOOL: str = "build/reqstool"
+    OUTPUT_SDIST_REQSTOOL_YML: str = "reqstool_config.yml"
+
+    ARCHIVE_OUTPUT_DIR_TEST_RESULTS: str = "test_results"
+
+    YAML_LANGUAGE_SERVER = "# yaml-language-server: $schema=https://raw.githubusercontent.com/Luftfartsverket/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_index.schema.json\n"  # noqa: E501
+
+    def activate(self, poetry: Poetry, cleo_io: IO) -> None:
+        self._poetry = poetry
+        self._cleo_io = cleo_io
+        cleo_io.write_line("INSIDE ACTIVATE IN POETRY-PLUGIN")
+
+        # pythonpath_from_pyproject_toml = (
+        #     poetry.pyproject.data.get("tool").get("pytest").get("ini_options").get("pythonpath")
+        # )
+
+        # filtered_pythonpaths: list[str] = [path for path in pythonpath_from_pyproject_toml if path != "."]
+
+        self._create_annotations_file(poetry=poetry)
+        # self._append_to_sdist_tar_gz(cleo_io=self._cleo_io, poetry=self._poetry)
+
+    @property
+    def post_build_handlers(self):
+        return [self.handle_post_build]
+
+    def handle_post_build(self, builder: Any, **kwargs: dict[str, Any]) -> None:
+        if isinstance(builder, (WheelBuilder, SdistBuilder)):
+            self._cleo_io.write_line("APPENDING TO TAR.GZ")
+
+            self._append_to_sdist_tar_gz(cleo_io=self._cleo_io, poetry=self._poetry)
+
+    def _create_annotations_file(self, poetry: Poetry) -> None:
+        """
+        Generates the annotations.yml file by processing the reqstool decorators.
+        """
+        sources = poetry.pyproject.data.get("tool", {}).get("reqstool", {}).get(self.CONFIG_SOURCES, ["src", "tests"])
+
+        reqstool_output_directory: Path = Path(
+            poetry.pyproject.data.get("tool", {})
+            .get("reqstool", {})
+            .get(self.CONFIG_OUTPUT_DIRECTORY, self.OUTPUT_DIR_REQSTOOL)
+        )
+        annotations_file: Path = Path(reqstool_output_directory, self.INPUT_FILE_ANNOTATIONS_YML)
+
+        decorator_processor = DecoratorProcessor()
+        decorator_processor.process_decorated_data(path_to_python_files=sources, output_file=str(annotations_file))
+
+    def _append_to_sdist_tar_gz(self, cleo_io: IO, poetry: Poetry) -> None:
+        """
+        Appends to sdist containing the annotations file and other necessary data.
+        """
+        dataset_directory: Path = Path(
+            poetry.pyproject.data.get("tool", {})
+            .get("reqstool", {})
+            .get(self.CONFIG_DATASET_DIRECTORY, self.INPUT_DIR_DATASET)
+        )
+        reqstool_output_directory: Path = Path(
+            poetry.pyproject.data.get("tool", {})
+            .get("reqstool", {})
+            .get(self.CONFIG_OUTPUT_DIRECTORY, self.OUTPUT_DIR_REQSTOOL)
+        )
+        test_result_patterns: list[str] = (
+            poetry.pyproject.data.get("tool", {}).get("reqstool", {}).get(self.CONFIG_TEST_RESULTS, [])
+        )
+        requirements_file: Path = Path(dataset_directory, self.INPUT_FILE_REQUIREMENTS_YML)
+        svcs_file: Path = Path(dataset_directory, self.INPUT_FILE_SOFTWARE_VERIFICATION_CASES_YML)
+        mvrs_file: Path = Path(dataset_directory, self.INPUT_FILE_MANUAL_VERIFICATION_RESULTS_YML)
+        annotations_file: Path = Path(reqstool_output_directory, self.INPUT_FILE_ANNOTATIONS_YML)
+
+        resources: dict[str, str] = {}
+
+        if not os.path.exists(requirements_file):
+            msg: str = f"[reqstool] missing mandatory {self.INPUT_FILE_REQUIREMENTS_YML}: {requirements_file}"
+            raise RuntimeError(msg)
+
+        resources["requirements"] = str(requirements_file)
+        cleo_io.write_line(f"[reqstool] added to {self.OUTPUT_SDIST_REQSTOOL_YML}: {requirements_file}")
+
+        if os.path.exists(svcs_file):
+            resources["software_verification_cases"] = str(svcs_file)
+            cleo_io.write_line(f"[reqstool] added to {self.OUTPUT_SDIST_REQSTOOL_YML}: {svcs_file}")
+
+        if os.path.exists(mvrs_file):
+            resources["manual_verification_results"] = str(mvrs_file)
+            cleo_io.write_line(f"[reqstool] added to {self.OUTPUT_SDIST_REQSTOOL_YML}: {mvrs_file}")
+
+        if os.path.exists(annotations_file):
+            resources["annotations"] = str(annotations_file)
+            cleo_io.write_line(f"[reqstool] added to {self.OUTPUT_SDIST_REQSTOOL_YML}: {annotations_file}")
+
+        if test_result_patterns:
+            resources["test_results"] = test_result_patterns
+            cleo_io.write_line(
+                f"[reqstool] added test_results to {self.OUTPUT_SDIST_REQSTOOL_YML}: {test_result_patterns}"
+            )
+
+        reqstool_yaml_data = {"language": "python", "build": "hatch", "resources": resources}
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+        reqstool_yml_io = io.BytesIO()
+        reqstool_yml_io.write(f"{self.YAML_LANGUAGE_SERVER}\n".encode("utf-8"))
+        reqstool_yml_io.write(f"# version: {poetry.package.version}\n".encode("utf-8"))
+
+        cleo_io.write_line(f"[reqstool] reqstool config {reqstool_yaml_data}")
+
+        yaml.dump(reqstool_yaml_data, reqstool_yml_io)
+        reqstool_yml_io.seek(0)
+        poetry.package.name
+        # Path to the existing tar.gz file (constructed from metadata)
+        original_tar_gz_file = os.path.join(
+            str(poetry.package.root_dir),
+            "dist",
+            f"{normalize_package_name(poetry.package.name)}-{poetry.package.version}.tar.gz",
         )
 
-        filtered_pythonpaths = [path for path in pythonpath_from_pyproject_toml if path != "."]
+        cleo_io.write_line(f"[reqstool] tarball: {original_tar_gz_file}")
 
-        generate_yaml_from_process_decorator(paths=filtered_pythonpaths)
+        # Step 1: Extract the original tar.gz file to a temporary directory
+        with tempfile.NamedTemporaryFile(delete=True) as temp_tar_file:
+
+            temp_tar_file = temp_tar_file.name  # Get the name of the temporary file
+
+            cleo_io.write_line(f"[reqstool] temporary tar file: {temp_tar_file}")
+
+            # Extract the original tar.gz file
+            with gzip.open(original_tar_gz_file, "rb") as f_in, open(temp_tar_file, "wb") as f_out:
+                f_out.write(f_in.read())
+
+            # Step 2: Open the extracted tar file and append the new file
+            with tarfile.open(temp_tar_file, "a") as archive:
+                file_info = tarfile.TarInfo(
+                    name=f"{normalize_package_name(poetry.package.name)}-"
+                    f"{poetry.package.version}/{self.OUTPUT_SDIST_REQSTOOL_YML}"
+                )
+                file_info.size = reqstool_yml_io.getbuffer().nbytes
+                archive.addfile(tarinfo=file_info, fileobj=reqstool_yml_io)
+
+            # Step 3: Recompress the updated tar file back into the original .tar.gz format
+            with open(temp_tar_file, "rb") as f_in, gzip.open(original_tar_gz_file, "wb") as f_out:
+                f_out.writelines(f_in)
+
+        dist_dir: Path = Path(str(poetry.package.root_dir))
+        cleo_io.write_line(
+            f"[reqstool] added {self.OUTPUT_SDIST_REQSTOOL_YML} to "
+            f"{os.path.relpath(original_tar_gz_file, dist_dir.parent)}"
+        )
 
 
-def generate_yaml_from_process_decorator(paths):
-    process_decorator = DecoratorProcessor()
-    process_decorator.process_decorated_data(path_to_python_files=paths)
+def get_version() -> str:
+    try:
+        ver: str = f"{version('reqstool-python-hatch-plugin')}"
+    except PackageNotFoundError:
+        ver: str = "package-not-found"
+
+    return ver
+
+
+def normalize_package_name(name: str) -> str:
+    return name.lower().replace("-", "_")


### PR DESCRIPTION
Add reqstool_config.yml to project root.

I did not find any way for the plugin to run `post build` so i could not solve this in a similar manner as we did in the hatch plugin.

Got stuck on the plugin trying to access the tar.gz file before it was created.

There might be a solution creating a custom SdistBuilder:

```python
from poetry.core.masonry.builders.sdist import SdistBuilder
```

I'm not sure this is possible and could not see any easy solution.


In the end i simply generate the `reqstool_config.yml` in the root of the project, this way it's included in the tar.gz file.

It's not perfect, but the end result is the same as the hatch plugin.