### PR TITLE
fix(ci): update release tag check to support PEP 440 pre-release versions

### DIFF
--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - name: Check tag format
         run: |
-          if ! echo "${{ github.ref }}" | grep -qE '^refs/tags/[0-9]+\.[0-9]+\.[0-9]+'; then
-            echo "Tag must be a semver version like 1.2.3 (no v prefix)"
+          if ! echo "${{ github.ref }}" | grep -qE '^refs/tags/[0-9]+(\.[0-9]+)*(a[0-9]+|b[0-9]+|rc[0-9]+)?(\.post[0-9]+)?(\.dev[0-9]+)?$'; then
+            echo "Tag must be a PEP 440 version like 1.2.3, 1.2.3a1, 1.2.3b2, 1.2.3rc1, 1.2.3.post1 (no v prefix)"
             exit 1
           fi
       - name: Check branch


### PR DESCRIPTION
## Summary

- Updates the tag format regex in `check_release.yml` from a plain semver pattern to a full PEP 440 compliant pattern
- Adds `$` anchor to prevent partial matches
- Allows pre-release identifiers: `1.2.3a1` (alpha), `1.2.3b2` (beta), `1.2.3rc1` (release candidate), `1.2.3.post1` (post-release), `1.2.3.dev1` (dev)

## Motivation

The old regex `^refs/tags/[0-9]+\.[0-9]+\.[0-9]+` blocked publishing pre-release versions to PyPI, which is needed to test the publish pipeline without relying on Test PyPI.

## Test plan

- [ ] Verify regex locally: `echo "refs/tags/1.2.3a1" | grep -qE '^refs/tags/[0-9]+(\.[0-9]+)*(a[0-9]+|b[0-9]+|rc[0-9]+)?(\.post[0-9]+)?(\.dev[0-9]+)?$' && echo ok`
- [ ] Confirm stable releases (`1.2.3`) still pass
- [ ] Confirm invalid tags (`v1.2.3`, bare strings) are still rejected