### PR TITLE
fix(ci): bump Poetry version to 2.4.1 to match plugin dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install and configure Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
         with:
-          version: 2.3.2
+          version: 2.4.1
           virtualenvs-create: true
       - name: Install poetry-dynamic-versioning
         run: poetry self add "poetry-dynamic-versioning[plugin]"


### PR DESCRIPTION
## Summary

The plugin's `pyproject.toml` declares `poetry = "2.4.1"` as a dependency, but the CI was installing Poetry `2.3.2`. This caused `poetry self add` (used in e2e tests to install the plugin into Poetry itself) to fail with a version conflict.

## Fix

Bump `version: 2.3.2` → `version: 2.4.1` in the `snok/install-poetry` step.

## Test plan

- [ ] CI build passes