### PR TITLE
fix(claude): commit .claude/settings.json to auto-enable reqstool plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "extraKnownMarketplaces": {
+    "reqstool-ai": {
+      "source": {
+        "source": "github",
+        "repo": "reqstool/reqstool-ai"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "reqstool@reqstool-ai": true,
+    "reqstool-openspec@reqstool-ai": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -283,4 +283,5 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/python,intellij+all,visualstudiocode
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/settings.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ cd reqstool-python-poetry-plugin
 poetry install
 ```
 
+If using Claude Code, regenerate the `opsx` slash commands and OpenSpec skills
+(`.claude/commands/opsx/`, `.claude/skills/openspec-*`) after cloning — they're
+CLI-generated tool scaffolding, not committed to the repo:
+
+```bash
+openspec update   # or: openspec init --tools claude --force
+```
+
 ## Build & Test
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ For DCO sign-off, commit conventions, and code review process, see the organizat
 
 - Python 3.13+
 - [Poetry](https://python-poetry.org/)
+- [reqstool](https://github.com/reqstool/reqstool-client) (`pipx install reqstool`)
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec) (`npm install -g @fission-ai/openspec`)
 
 ## Setup
 
@@ -17,9 +19,13 @@ cd reqstool-python-poetry-plugin
 poetry install
 ```
 
-If using Claude Code, regenerate the `opsx` slash commands and OpenSpec skills
-(`.claude/commands/opsx/`, `.claude/skills/openspec-*`) after cloning — they're
-CLI-generated tool scaffolding, not committed to the repo:
+If using Claude Code, opening this repo will prompt you to confirm adding the `reqstool-ai`
+marketplace and enabling the `reqstool`/`reqstool-openspec` plugins (configured in
+`.claude/settings.json`) — accept the prompt.
+
+Then regenerate the `opsx` slash commands and OpenSpec skills
+(`.claude/commands/opsx/`, `.claude/skills/openspec-*`) — they're CLI-generated tool scaffolding,
+not committed to the repo:
 
 ```bash
 openspec update   # or: openspec init --tools claude --force


### PR DESCRIPTION
## Summary
- `.claude/` was blanket-gitignored, so the `reqstool@reqstool-ai` / `reqstool-openspec@reqstool-ai` plugin auto-enable config that `reqstool-client` commits (`.claude/settings.json` with `extraKnownMarketplaces` + `enabledPlugins`) was never added to this repo. A local-only `.claude/settings.json` did exist but was missing `extraKnownMarketplaces`.
- Verified against `~/.claude/plugins/installed_plugins.json` locally: these plugins were only project-scoped to `atunko` and `reqstool-client`, never to this repo, despite #131's dogfooding PR having merged.
- Narrows `.gitignore` (`.claude/*` + `!.claude/settings.json`) and commits `.claude/settings.json`, mirroring [reqstool-client](https://github.com/reqstool/reqstool-client/blob/main/.claude/settings.json)'s pattern, so a fresh clone gets both plugins auto-enabled instead of requiring a manual per-checkout install.

## Test plan
- [x] `git diff .gitignore` confirms only the `.claude/` exception lines changed
- [x] `git status` confirms only `.gitignore` + `.claude/settings.json` are tracked (no other local `.claude/` cruft swept in)